### PR TITLE
feat/PROGINZ-51-Notifikacija-pri-uploadu-postojecih-pdfova-backend

### DIFF
--- a/IzvorniKod/Controllers/PdfController.cs
+++ b/IzvorniKod/Controllers/PdfController.cs
@@ -293,4 +293,26 @@ public class PdfController : Controller
         var removedLogs = await _managePdfService.GetAllRemovedLogsAsync(educatorId);
         return View(removedLogs);
     }
+    
+    [Authorize(Roles="SuperStudent,Educator")]
+    [HttpGet]
+    public async Task<IActionResult> FetchPdfByName([FromQuery] string pdfName, [FromQuery] bool isPublic)
+    {
+        var userId = _userManager.GetUserId(User);
+        if (string.IsNullOrEmpty(pdfName))
+        {
+            return BadRequest("PDF name is required.");
+        }
+
+        try
+        {
+            var exists = await _managePdfService.FetchPdfByNameAsync(pdfName, userId, isPublic);
+            return Ok(exists);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"Internal server error: {ex.Message}");
+        }
+    }
+    
 }

--- a/IzvorniKod/Views/Pdf/UploadPdf.cshtml
+++ b/IzvorniKod/Views/Pdf/UploadPdf.cshtml
@@ -4,10 +4,9 @@
 
 <h2>Upload PDF</h2>
 
-@*@if(User.IsInRole("SuperStudent")*@
-@if (!User.IsInRole("Educator"))
+@if (User.IsInRole("SuperStudent"))
 {
-    <form id="uploadPrivateForm" enctype="multipart/form-data">
+    <form id="uploadPrivateForm" action="@Url.Action("UploadPrivatePdf", "Pdf")" enctype="multipart/form-data">
         <div class="form-group">
             <label for="file">Select PDF:</label>
             <input class="form-control" type="file" id="file" name="file" required />
@@ -27,7 +26,7 @@
 
 @if (User.IsInRole("Educator"))
 {
-    <form id="uploadPublicForm" enctype="multipart/form-data">
+    <form id="uploadPublicForm" action="@Url.Action("UploadPublicPdf", "Pdf")" enctype="multipart/form-data">
         <div class="form-group">
             <label for="file">Select PDF:</label>
             <input class="form-control" type="file" id="file" name="file" required />
@@ -50,44 +49,59 @@
 
 @section Scripts {
     <script>
-        document.getElementById('uploadPrivateForm')?.addEventListener('submit', async function (event) {
-            event.preventDefault();
+        // notification update
+        async function checkAndSubmitForm(form, isPublic) {
+            const formData = new FormData(form);
+            const pdfName = formData.get('file').name;
+            const response = await fetch(`@Url.Action("FetchPdfByName", "Pdf")?pdfName=${encodeURIComponent(pdfName)}&isPublic=${isPublic}`, {
+                method: 'GET'
+            });
 
-            const formData = new FormData(this);
-            const response = await fetch('@Url.Action("UploadPrivatePdf", "Pdf")', {
+            const exists = await response.json();
+
+            if (exists) {
+                const confirmReplace = confirm("The PDF already exists. Do you want to replace it?");
+                if (!confirmReplace) {
+                    return;
+                }
+            }
+
+            const uploadResponse = await fetch(form.action, {
                 method: 'POST',
                 body: formData
             });
 
-            if (response.ok) {
+            if (uploadResponse.ok) {
                 document.getElementById('notification').style.display = 'block';
                 document.getElementById('error').style.display = 'none';
             } else {
-                const errorText = await response.text();
+                const errorText = await uploadResponse.text();
                 document.getElementById('error').innerText = `Error: ${errorText}`;
                 document.getElementById('error').style.display = 'block';
                 document.getElementById('notification').style.display = 'none';
             }
+        }
+
+        document.getElementById('uploadPrivateForm')?.addEventListener('submit', function (event) {
+            event.preventDefault();
+            checkAndSubmitForm(this, false);
         });
 
-        document.getElementById('uploadPublicForm')?.addEventListener('submit', async function (event) {
+        document.getElementById('uploadPublicForm')?.addEventListener('submit', function (event) {
             event.preventDefault();
+            checkAndSubmitForm(this, true);
+        });
 
-            const formData = new FormData(this);
-            const response = await fetch('@Url.Action("UploadPublicPdf", "Pdf")', {
-                method: 'POST',
-                body: formData
-            });
+        // hiding the success message (so that it is not constantly visible after one successful upload)
+        // same for the error message
+        document.getElementById('file').addEventListener('click', function () {
+            document.getElementById('notification').style.display = 'none';
+            document.getElementById('error').style.display = 'none';
+        });
 
-            if (response.ok) {
-                document.getElementById('notification').style.display = 'block';
-                document.getElementById('error').style.display = 'none';
-            } else {
-                const errorText = await response.text();
-                document.getElementById('error').innerText = `Error: ${errorText}`;
-                document.getElementById('error').style.display = 'block';
-                document.getElementById('notification').style.display = 'none';
-            }
+        document.getElementById('tagName').addEventListener('click', function () {
+            document.getElementById('notification').style.display = 'none';
+            document.getElementById('error').style.display = 'none';
         });
     </script>
 }


### PR DESCRIPTION
Dodana notifikacija u UploadPdf.cshtml (i pripadajuca backend nadogradnja sa servisom i rutom pdf/fetchpdfbyname koju koristi js)

Fixani stari problemi:
- prikaz za SuperStudente umjesto sve usere osim Edukatora na UploadPdf.cshtml
- kao i kod edukatora, sada kada student odluci zamjenit existing file izbrise ga prije nego sto ga ponovno uploada (umjesto da ga samo edita)
- successfully uploaded poruka vise nije konstantno displayjana nakon jednog uspješnog uploada