### PR TITLE
bug/PROGINZ-60-Bugfix-isPublic-kod-EducatorPdf-na-Indexu

### DIFF
--- a/IzvorniKod/Services/ManagePdfService.cs
+++ b/IzvorniKod/Services/ManagePdfService.cs
@@ -134,7 +134,7 @@ public class ManagePdfService : IManagePdfService
                 PdfName = sp.PublicPdf.PdfName,
                 Rating = sp.PublicPdf.Rating,
                 TagName = sp.PublicPdf.PublicPdfTag.Tag.TagName,
-                IsPublic = false
+                IsPublic = true
             })
             .ToListAsync();
 


### PR DESCRIPTION
Popravljen bug u kojem edukator nije mogao otvarati svoje pdfove na indexu te u kojem se edukatoru za pdf prikazivalo private umjesto public na indexu.